### PR TITLE
crud: upgrade tarantool/crud version to 0.10.0

### DIFF
--- a/try-cartridge-scm-1.rockspec
+++ b/try-cartridge-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'cartridge == 2.7.3-1',
     'analytics == scm-1',
     'cartridge-extensions == scm-1',
-    'crud == 0.8.0'
+    'crud == 0.10.0'
 }
 
 build = {


### PR DESCRIPTION
This PR upgrades crud to version 0.10.0 to upgrade crud and ddl integration required to pass tutorial